### PR TITLE
Fix and support

### DIFF
--- a/Example/PPComLib/PPViewController.m
+++ b/Example/PPComLib/PPViewController.m
@@ -36,6 +36,12 @@
     
     [[PPSDK sharedSDK] configure:sdkConfiguration];
     
+    // Customer user info
+    PPServiceUser *user = [[PPServiceUser alloc] init];
+    user.userName = @"JasonLi";
+    user.userIcon = @"https://avatars1.githubusercontent.com/u/7382247?v=3&u=dd690117b1933bea61be9eccd6feab806bf52c4d&s=140";
+    [PPSDK sharedSDK].user = user;
+    
     // Start PPSDK
     [[PPSDK sharedSDK] start];
     

--- a/PPComLib/Classes/PPComLib.h
+++ b/PPComLib/Classes/PPComLib.h
@@ -12,6 +12,7 @@
 
 #import "PPConversationItem.h"
 #import "PPMessage.h"
+#import "PPServiceUser.h"
 
 // =====================
 // Controllers

--- a/PPComLib/Classes/PPSDK.m
+++ b/PPComLib/Classes/PPSDK.m
@@ -80,6 +80,9 @@ NSString *const PPSDKMessageSendFailed = @"PPSDKMessageSendFailed";
         [_fetchUnackedMessagesTask cancel];
         _fetchUnackedMessagesTask = nil;
     }
+    if (_startUpHelper) {
+        _startUpHelper = nil;
+    }
 }
 
 - (BOOL)isStarted {

--- a/PPComLib/Classes/api/PPAPI.h
+++ b/PPComLib/Classes/api/PPAPI.h
@@ -71,6 +71,8 @@ typedef NS_ENUM(NSInteger, PPMessageCustomErrorCode) {
 
 - (void)getUserUuid:(NSDictionary*)params completionHandler:(PPAPICompletedBlock)completionHandler;
 
+- (void)updatePPComUser:(NSDictionary *)params completionHandler:(PPAPICompletedBlock)completionHandler ;
+
 - (void)getPPComDeviceUser:(NSDictionary*)params completionHandler:(PPAPICompletedBlock)completionHandler;
 
 - (void)createDevice:(NSDictionary*)params completionHandler:(PPAPICompletedBlock)completionHandler;

--- a/PPComLib/Classes/api/PPAPI.m
+++ b/PPComLib/Classes/api/PPAPI.m
@@ -277,6 +277,10 @@ static NSString *const kPPHeaderTypePPCom = @"PPCOM";
     [self basePPComRequest:@"/PP_GET_USER_UUID" with:params completionHandler:completionHandler];
 }
 
+- (void)updatePPComUser:(NSDictionary *)params completionHandler:(PPAPICompletedBlock)completionHandler {
+    [self basePPComRequest:@"/PP_UPDATE_USER" with:params completionHandler:completionHandler];
+}
+
 - (void)getPPComDeviceUser:(NSDictionary*)params completionHandler:(PPAPICompletedBlock)completionHandler {
     [self basePPComRequest:@"/PP_GET_USER_INFO" with:params completionHandler:completionHandler];
 }

--- a/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.h
+++ b/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.h
@@ -19,4 +19,9 @@
 - (void)getUserUUIDWithEmail:(NSString*)userEmail
                    withBlock:(PPHttpModelCompletedBlock)aBlock;
 
+- (void)getUserUUIDWithEmail:(NSString*)userEmail
+                    withIcon:(NSString *)userIcon
+                withFullname:(NSString *)userFullName
+                   withBlock:(PPHttpModelCompletedBlock)aBlock;
+
 @end

--- a/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.m
+++ b/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.m
@@ -55,8 +55,8 @@
                    withBlock:(PPHttpModelCompletedBlock)aBlock {
     
     NSDictionary *params = @{ @"user_email":userEmail,
-                              @"user_icon":userIcon,
-                              @"user_fullname":userFullName,
+                              @"user_icon":userIcon?userIcon:@"",
+                              @"user_fullname":userFullName?userFullName:@"",
                               @"app_uuid":self.sdk.app.appUuid };
     [self.sdk.api getUserUuid:params completionHandler:^(NSDictionary *response, NSDictionary *error) {
         

--- a/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.m
+++ b/PPComLib/Classes/service/http/PPGetUserUUIDHttpModel.m
@@ -49,4 +49,29 @@
     }];
 }
 
+- (void)getUserUUIDWithEmail:(NSString *)userEmail
+                    withIcon:(NSString *)userIcon
+                withFullname:(NSString *)userFullName
+                   withBlock:(PPHttpModelCompletedBlock)aBlock {
+    
+    NSDictionary *params = @{ @"user_email":userEmail,
+                              @"user_icon":userIcon,
+                              @"user_fullname":userFullName,
+                              @"app_uuid":self.sdk.app.appUuid };
+    [self.sdk.api getUserUuid:params completionHandler:^(NSDictionary *response, NSDictionary *error) {
+        
+        NSString *userUUID = nil;
+        if (!error && !PPIsApiResponseError(response)) {
+            userUUID = [response objectForKey:@"user_uuid"];
+        }
+        
+        if (aBlock) {
+            aBlock(userUUID, response, [NSError errorWithDomain:PPErrorDomain
+                                                           code:PPErrorCodeAPIError
+                                                       userInfo:error]);
+        }
+        
+    }];
+}
+
 @end

--- a/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.h
+++ b/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.h
@@ -18,6 +18,7 @@
 
 - (void)updateUserWithUUID:(NSString*)userUUID
                   withIcon:(NSString *)userIcon
+              withFullName:(NSString *)fullName
                  withBlock:(PPHttpModelCompletedBlock)aBlock;
 
 @end

--- a/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.h
+++ b/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.h
@@ -1,0 +1,23 @@
+//
+//  PPUpdateUserInfoHttpModel.h
+//  Pods
+//
+//  Created by Jason Li on 8/16/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#import "PPHttpModel.h"
+
+@class PPSDK;
+
+@interface PPUpdateUserInfoHttpModel : NSObject
+
+- (instancetype)initWithSDK:(PPSDK*)sdk;
+
+- (void)updateUserWithUUID:(NSString*)userUUID
+                  withIcon:(NSString *)userIcon
+                 withBlock:(PPHttpModelCompletedBlock)aBlock;
+
+@end

--- a/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
+++ b/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
@@ -35,7 +35,7 @@
                  withBlock:(PPHttpModelCompletedBlock)aBlock {
     
     NSDictionary *params = @{ @"user_uuid":self.sdk.user.userUuid,
-                              @"user_icon":userIcon,
+                              @"user_icon":userIcon?userIcon:@"",
                               @"app_uuid":self.sdk.app.appUuid };
     [self.sdk.api updatePPComUser:params completionHandler:^(NSDictionary *response, NSDictionary *error) {
         NSString *userUUID = nil;

--- a/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
+++ b/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
@@ -1,0 +1,54 @@
+//
+//  PPUpdateUserInfoHttpModel.m
+//  Pods
+//
+//  Created by Jason Li on 8/16/16.
+//
+//
+
+#import "PPUpdateUserInfoHttpModel.h"
+
+#import "PPSDK.h"
+#import "PPAPI.h"
+#import "PPApp.h"
+#import "PPServiceUser.h"
+
+#import "PPSDKUtils.h"
+
+@interface PPUpdateUserInfoHttpModel ()
+
+@property (nonatomic) PPSDK *sdk;
+
+@end
+
+@implementation PPUpdateUserInfoHttpModel
+
+- (instancetype)initWithSDK:(PPSDK *)sdk {
+    if (self = [super init]) {
+        self.sdk = sdk;
+    }
+    return self;
+}
+
+- (void)updateUserWithUUID:(NSString *)userUUID
+                  withIcon:(NSString *)userIcon
+                 withBlock:(PPHttpModelCompletedBlock)aBlock {
+    
+    NSDictionary *params = @{ @"user_uuid":self.sdk.user.userUuid,
+                              @"user_icon":userIcon,
+                              @"app_uuid":self.sdk.app.appUuid };
+    [self.sdk.api updatePPComUser:params completionHandler:^(NSDictionary *response, NSDictionary *error) {
+        NSString *userUUID = nil;
+        if (!error && !PPIsApiResponseError(response)) {
+            userUUID = [response objectForKey:@"user_uuid"];
+        }
+        
+        if (aBlock) {
+            aBlock(userUUID, response, [NSError errorWithDomain:PPErrorDomain
+                                                           code:PPErrorCodeAPIError
+                                                       userInfo:error]);
+        }
+    }];
+    
+}
+@end

--- a/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
+++ b/PPComLib/Classes/service/http/PPUpdateUserInfoHttpModel.m
@@ -32,10 +32,12 @@
 
 - (void)updateUserWithUUID:(NSString *)userUUID
                   withIcon:(NSString *)userIcon
+              withFullName:(NSString *)fullName
                  withBlock:(PPHttpModelCompletedBlock)aBlock {
     
     NSDictionary *params = @{ @"user_uuid":self.sdk.user.userUuid,
                               @"user_icon":userIcon?userIcon:@"",
+                              @"user_fullname":fullName?fullName:@"",
                               @"app_uuid":self.sdk.app.appUuid };
     [self.sdk.api updatePPComUser:params completionHandler:^(NSDictionary *response, NSDictionary *error) {
         NSString *userUUID = nil;

--- a/PPComLib/Classes/utils/PPSDKStartUpHelper.m
+++ b/PPComLib/Classes/utils/PPSDKStartUpHelper.m
@@ -155,14 +155,17 @@
                 return;
             }
             NSString *userNewIcon = self.sdk.user.userIcon;
+            NSString *userNewName = self.sdk.user.userName;
             self.sdk.user = user;
             
             // update user icon
-            if (![self.sdk.user.userIcon isEqualToString:userNewIcon]) {
+            if (![self.sdk.user.userIcon isEqualToString:userNewIcon] ||
+                ![self.sdk.user.userName isEqualToString:userNewName]) {
                 self.sdk.user.userIcon = userNewIcon;
+                self.sdk.user.userName = userNewName;
                 
                 PPUpdateUserInfoHttpModel *updateUserInfoHttpModel = [[PPUpdateUserInfoHttpModel alloc] initWithSDK:self.sdk];
-                [updateUserInfoHttpModel updateUserWithUUID:userUUID withIcon:userNewIcon withBlock:nil];
+                [updateUserInfoHttpModel updateUserWithUUID:userUUID withIcon:userNewIcon withFullName:userNewName withBlock:nil];
             }
             if (block) block();
         }];

--- a/PPComLib/Classes/utils/PPSDKStartUpHelper.m
+++ b/PPComLib/Classes/utils/PPSDKStartUpHelper.m
@@ -13,6 +13,7 @@
 #import "PPCreateDeviceHttpModel.h"
 #import "PPUpdateDeviceHttpModel.h"
 #import "PPCreateAnonymousUserHttpModel.h"
+#import "PPUpdateUserInfoHttpModel.h"
 
 #import "PPNetworkHelper.h"
 #import "PPWebSocket.h"
@@ -141,7 +142,7 @@
 
 - (void)emailUser:(PPNoArgBlock)block {
     PPGetUserUUIDHttpModel *getUserUUIDHttpModel = [[PPGetUserUUIDHttpModel alloc] initWithSDK:self.sdk];
-    [getUserUUIDHttpModel getUserUUIDWithEmail:self.sdk.configuration.email withBlock:^(id userUUID, NSDictionary *response, NSError *error) {
+    [getUserUUIDHttpModel getUserUUIDWithEmail:self.sdk.configuration.email withIcon:self.sdk.user.userIcon withFullname:self.sdk.user.userName withBlock:^(id userUUID, NSDictionary *response, NSError *error) {
         if (!userUUID) {
             [self onStartFail:error];
             return;
@@ -153,7 +154,16 @@
                 [self onStartFail:error];
                 return;
             }
+            NSString *userNewIcon = self.sdk.user.userIcon;
             self.sdk.user = user;
+            
+            // update user icon
+            if (![self.sdk.user.userIcon isEqualToString:userNewIcon]) {
+                self.sdk.user.userIcon = userNewIcon;
+                
+                PPUpdateUserInfoHttpModel *updateUserInfoHttpModel = [[PPUpdateUserInfoHttpModel alloc] initWithSDK:self.sdk];
+                [updateUserInfoHttpModel updateUserWithUUID:userUUID withIcon:userNewIcon withBlock:nil];
+            }
             if (block) block();
         }];
     }];

--- a/PPComLib/Classes/utils/download/PPDownloader.m
+++ b/PPComLib/Classes/utils/download/PPDownloader.m
@@ -61,7 +61,9 @@ static NSString *const PPDownloaderDiskCacheFolder = @"PPFileCache";
                     aBlock(nil, fileUUID, fileURLString);
                 } else {
                     [wself storeFile:responseObject forFileUUID:fileUUID done:^{
-                        aBlock(responseObject, fileUUID, fileURLString);
+                        NSString *md5Key = [self MD5KeyForFileUUID:fileUUID];
+                        NSString *filePath = [self fileDiskPathWithMD5Key:md5Key];
+                        aBlock(responseObject, fileUUID, filePath);
                     }];
                 }
             }];
@@ -111,14 +113,15 @@ static NSString *const PPDownloaderDiskCacheFolder = @"PPFileCache";
         dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
         dispatch_async(queue, ^{
             @autoreleasepool {
-                NSData *data = PPReadDataFromFileAtURL([NSURL URLWithString:[self fileDiskPathWithMD5Key:md5Key]]);
+                NSString *fileDiskPath = [self fileDiskPathWithMD5Key:md5Key];
+                NSData *data = PPReadDataFromFileAtURL([NSURL URLWithString:fileDiskPath]);
                 if (data) {
                     PPFastLog(@"[PPDownloader] find file from disk with file uuid: %@", fileUUID);
                     [self.fileMemoryCache setObject:data forKey:md5Key];
                 }
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    aBlock(data, fileUUID, fileLocalPath);
+                    aBlock(data, fileUUID, fileDiskPath);
                 });
             }
         });

--- a/PPComLib@JL.podspec
+++ b/PPComLib@JL.podspec
@@ -1,0 +1,87 @@
+#
+# Be sure to run `pod lib lint PPComLib.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'PPComLib@JL'
+  s.version          = '0.1.7.1'
+  s.summary          = 'PPCom-iOS-SDK for PPMessage'
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+TODO: Add long description of the pod here.
+                       DESC
+
+  s.homepage         = 'https://github.com/JasonRSTX/ppcom-ios-sdk'
+  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'JasonLi' => 'rstx_reg@aliyun.com' }
+  s.source           = { :git => 'https://github.com/JasonRSTX/ppcom-ios-sdk.git', :tag => s.version.to_s }
+  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+
+  s.ios.deployment_target = '8.0'
+
+  s.source_files = 'PPComLib/Classes/**/*'
+  #s.source_files = 'PPComLib/Classes/PPComLib.h,PPComLib/Classes/PPSDK.{h,m},PPComLib/Classes/PPSDKConfiguration.{h,m}'
+  #s.public_header_files = 'PPComLib/Classes/PPComLib.h,PPComLib/Classes/PPSDK.h,PPComLib/Classes/PPSDKConfiguration.h'
+  
+  #s.resource_bundles = {
+  #   'PPComLibAssets' => ['PPComLib/Assets/*.*']
+  #}
+
+  #s.subspec 'api' do |api|
+  #  api.source_files = 'PPComLib/Classes/api/**/*.*'
+  #  api.public_header_files = 'PPComLib/Classes/api/**/*.h'
+  #end
+  
+  #s.subspec 'bean' do |bean|
+  #  bean.source_files = 'PPComLib/Classes/bean/**/*.*'
+  #  bean.public_header_files = 'PPComLib/Classes/bean/**/*.h'
+  #end
+  
+  #s.subspec 'controllers' do |controllers|
+  #  controllers.source_files = 'PPComLib/Classes/controllers/**/*.*'
+  #  controllers.public_header_files = 'PPComLib/Classes/controllers/*.h'
+  #end
+
+  #s.subspec 'mock' do |mock|
+  #  mock.source_files = 'PPComLib/Classes/mock/**/*.*'
+  #  mock.public_header_files = 'PPComLib/Classes/mock/**/*.h'
+  #end
+  
+  #s.subspec 'notification' do |notification|
+  #  notification.source_files = 'PPComLib/Classes/notification/**/*.*'
+  #  notification.public_header_files = 'PPComLib/Classes/notification/**/*.h'
+  #end
+  
+  #s.subspec 'service' do |service|
+  #  service.source_files = 'PPComLib/Classes/service/**/*.*'
+  #  service.public_header_files = 'PPComLib/Classes/service/**/*.h'
+  #end
+  
+  #s.subspec 'utils' do |utils|
+  #  utils.source_files = 'PPComLib/Classes/utils/**/*.*'
+  #  utils.public_header_files = 'PPComLib/Classes/utils/**/*.h'
+  #end
+  
+  #s.subspec 'view' do |view|
+  #  view.source_files = 'PPComLib/Classes/view/**/*.*'
+  #  view.public_header_files = 'PPComLib/Classes/view/**/*.h'
+  #end
+
+  # s.public_header_files = 'Pod/Classes/**/*.h'
+  # s.frameworks = 'UIKit', 'MapKit'
+  s.dependency 'AFNetworking', '~> 3.0'
+  s.dependency 'SDWebImage', '~>3.8.1'
+  s.dependency 'PPJTSImageViewController'
+  s.dependency 'SocketRocket'
+end


### PR DESCRIPTION
1、发现客户端应用重新启动后，语音文件无法播放。
--原因是使用AVAudioPlayer播放了一个网络音频。
--在PPDownloader中直接返回已下载至缓存的音频文件Path，提供给AVAudioPlayer播放。

2、集成过程中存在设置PPCom用户FullName和UserIcon的需求，以及修改FullName和UserIcon的需求。
--通过sdk.user的属性userName，userIcon传入PPSDKStartUpHelper，并在PPGetUserUUIDHttpModel中重载了方法（-(void)getUserUUIDWithEmail:withIcon:withFullname:withBlock）实现设置姓名和头像的需求。
--增加Model（PPUpdateUserInfoHttpModel）实现修改已注册用户的姓名和头像的需求。

ps:目前服务端提供的接口“PP_UPDATE_USER”无法修改用户姓名（userFullName），望增加功能。
